### PR TITLE
✨ feat: 添加AI API请求超时时间设置功能

### DIFF
--- a/app/src/main/java/top/galqq/config/ConfigManager.java
+++ b/app/src/main/java/top/galqq/config/ConfigManager.java
@@ -131,6 +131,10 @@ public class ConfigManager {
     public static final float DEFAULT_AI_QPS = 3.0f;
     public static final String KEY_AI_QPS = "gal_ai_qps";
     
+    // AI Timeout Default Value (主AI超时时间)
+    public static final int DEFAULT_AI_TIMEOUT = 30; // 默认30秒
+    public static final String KEY_AI_TIMEOUT = "gal_ai_timeout";
+    
     // Proxy Keys (代理配置)
     public static final String KEY_PROXY_ENABLED = "gal_proxy_enabled";
     public static final String KEY_PROXY_TYPE = "gal_proxy_type";
@@ -581,6 +585,22 @@ public class ConfigManager {
     
     public static void setAiQps(float qps) {
         getMmkv().encode(KEY_AI_QPS, qps);
+    }
+    
+    /**
+     * 获取主AI请求超时时间（秒）
+     * @return 超时时间
+     */
+    public static int getAiTimeout() {
+        return getMmkv().decodeInt(KEY_AI_TIMEOUT, DEFAULT_AI_TIMEOUT);
+    }
+    
+    /**
+     * 设置主AI请求超时时间（秒）
+     * @param timeout 超时时间
+     */
+    public static void setAiTimeout(int timeout) {
+        getMmkv().encode(KEY_AI_TIMEOUT, timeout);
     }
 
     public static String getDictPath() {

--- a/app/src/main/java/top/galqq/ui/GalSettingsFragment.java
+++ b/app/src/main/java/top/galqq/ui/GalSettingsFragment.java
@@ -281,6 +281,31 @@ public class GalSettingsFragment extends PreferenceFragmentCompat {
             });
         }
         
+        // AI Timeout (请求超时时间)
+        EditTextPreference aiTimeoutPref = findPreference(ConfigManager.KEY_AI_TIMEOUT);
+        if (aiTimeoutPref != null) {
+            aiTimeoutPref.setText(String.valueOf(ConfigManager.getAiTimeout()));
+            aiTimeoutPref.setSummary("当前: " + ConfigManager.getAiTimeout() + " 秒 (读取超时: " + (ConfigManager.getAiTimeout() * 2) + " 秒)");
+            aiTimeoutPref.setOnPreferenceChangeListener((preference, newValue) -> {
+                try {
+                    int timeout = Integer.parseInt((String) newValue);
+                    if (timeout >= 1 && timeout <= 600) {
+                        ConfigManager.setAiTimeout(timeout);
+                        aiTimeoutPref.setText((String) newValue);
+                        aiTimeoutPref.setSummary("当前: " + timeout + " 秒 (读取超时: " + (timeout * 2) + " 秒)");
+                        // 重置AI客户端以使用新的超时配置
+                        top.galqq.utils.HttpAiClient.resetClient();
+                        return true;
+                    } else {
+                        android.widget.Toast.makeText(requireContext(), "超时时间范围: 1-600秒", android.widget.Toast.LENGTH_SHORT).show();
+                    }
+                } catch (Exception e) {
+                    android.widget.Toast.makeText(requireContext(), "请输入有效的超时时间", android.widget.Toast.LENGTH_SHORT).show();
+                }
+                return false;
+            });
+        }
+        
         // Context Enabled (启用对话上下文)
         Preference contextEnabledSwitch = findPreference(ConfigManager.KEY_CONTEXT_ENABLED);
         if (contextEnabledSwitch != null) {

--- a/app/src/main/res/xml/preferences_gal.xml
+++ b/app/src/main/res/xml/preferences_gal.xml
@@ -74,6 +74,13 @@
             android:inputType="numberDecimal"
             android:defaultValue="3.0" />
         
+        <EditTextPreference
+            android:key="gal_ai_timeout"
+            android:title="请求超时时间"
+            android:summary="AI API请求超时时间（秒），默认30秒，读取超时为2倍"
+            android:inputType="number"
+            android:defaultValue="30" />
+        
         <Preference
             android:key="gal_test_api"
             android:title="@string/gal_test_api_title"


### PR DESCRIPTION
## 添加AI API请求超时时间设置功能

- 在ConfigManager中添加KEY_AI_TIMEOUT配置项，默认30秒
- 修改HttpAiClient使用可配置的超时时间（读取超时为2倍）
- 在设置界面添加超时时间配置项（范围1-600秒）
- 配置变更时自动重置客户端以即时生效